### PR TITLE
Call next() directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ db.open(function () {
 
 ## API
 
-### `concat(iterator[, nextTick], cb)`
+### `concat(iterator, cb)`
 
-Takes an `abstract-leveldown` compatible `iterator` as first parameter and calls back with an array of keys and values. Second parameter is an optional function for handling `nextTick`, which defaults to `process.nextTick`. Calls back with an error if `iterator.next(cb)` or `iterator.end(cb)` errors.
+Takes an `abstract-leveldown` compatible `iterator` as first parameter and calls back with an array of keys and values. Calls back with an error if `iterator.next(cb)` or `iterator.end(cb)` errors.
 
 ## Contributing
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,4 @@
-module.exports = function (iterator, nextTick, cb) {
-  if (typeof cb !== 'function') {
-    cb = nextTick
-    nextTick = process.nextTick
-  }
+module.exports = function (iterator, cb) {
   var data = []
   var next = function () {
     iterator.next(function (err, key, value) {
@@ -13,7 +9,7 @@ module.exports = function (iterator, nextTick, cb) {
         })
       }
       data.push({ key: key, value: value })
-      nextTick(next)
+      next()
     })
   }
   next()

--- a/test.js
+++ b/test.js
@@ -101,20 +101,3 @@ test('calls back with error and partial data if iterator.end errors', function (
     t.same(result, [].concat(data[0]))
   })
 })
-
-test('supports custom nextTick', function (t) {
-  t.plan(2)
-
-  var iterator = {
-    next: function (cb) {
-      process.nextTick(cb, null, 'key', 'value')
-    }
-  }
-
-  function nextTick (next) {
-    t.is(typeof next, 'function', 'next is a function')
-    t.pass('custom nextTick called')
-  }
-
-  collect(iterator, nextTick, function () {})
-})


### PR DESCRIPTION
Closes https://github.com/Level/concat-iterator/issues/2

Tested with `memdown`, `leveldown` and `rocksdb`